### PR TITLE
add license identifier

### DIFF
--- a/contracts/GuessTheNumberGame.sol
+++ b/contracts/GuessTheNumberGame.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/Strings.sol";


### PR DESCRIPTION
As proposed in #4 , the contract should contain the license identifier.